### PR TITLE
bugfix: pass a copy of event in setState callback instead of a refere…

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -368,6 +368,8 @@ Validation.Input = React.createClass({
             value = !this.state.checked ? this.props.value : '';
         }
 
+        var eventClone = objectAssign({}, event);
+
         this.setState({
             isChanged: value !== this.state.value,
             isUsed: this.state.isUsed || !event,
@@ -376,7 +378,7 @@ Validation.Input = React.createClass({
         }, function() {
             (this.props._blocking || noop)(this);
             (this.props._validate || noop)(this);
-            (this.props.onChange || noop)(isEventPassed ? event : undefined);
+            (this.props.onChange || noop)(isEventPassed ? eventClone : undefined);
         });
     },
 


### PR DESCRIPTION
I believe I ran into a bug where the event object was modified before it was accessed in the setState callback function. Passing a copy of the event object instead will trigger what it intuitively should do.