### PR TITLE
Persist events dispatched to onChange

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -395,6 +395,11 @@ Validation.Input = React.createClass({displayName: "Input",
             value = !this.state.checked ? this.props.value : '';
         }
 
+        if (isEventPassed) {
+          // Persist the event since we will need this event outside this event loop.
+          event.persist();
+        }
+
         this.setState({
             isChanged: (value !== this.state.value) || (value !== this.state.lastValue),
             isUsed: this.state.isUsed || !event,
@@ -483,6 +488,11 @@ Validation.Select = React.createClass({displayName: "Select",
     setValue: function(value, event) {
         var isEventPassed = (event && event.nativeEvent instanceof Event);
 
+        if (isEventPassed) {
+          // Persist the event since we will need this event outside this event loop.
+          event.persist();
+        }
+        
         this.setState({
             value: value
         }, function() {

--- a/index.jsx
+++ b/index.jsx
@@ -395,6 +395,11 @@ Validation.Input = React.createClass({
             value = !this.state.checked ? this.props.value : '';
         }
 
+        if (isEventPassed) {
+          // Persist the event since we will need this event outside this event loop.
+          event.persist();
+        }
+
         this.setState({
             isChanged: (value !== this.state.value) || (value !== this.state.lastValue),
             isUsed: this.state.isUsed || !event,
@@ -483,6 +488,11 @@ Validation.Select = React.createClass({
     setValue: function(value, event) {
         var isEventPassed = (event && event.nativeEvent instanceof Event);
 
+        if (isEventPassed) {
+          // Persist the event since we will need this event outside this event loop.
+          event.persist();
+        }
+        
         this.setState({
             value: value
         }, function() {


### PR DESCRIPTION
In exploring https://github.com/Lesha-spr/react-validation/pull/8 with @kaela, we've found the underlying problem. Our `onChange` handler was receiving an event that was basically all `nulls`. We originally fixed that by explicitly passing `value` as a new parameter. However, the root cause is that the event object that is received by `setValue` is then later dispatched in the callback to `setState`, which happens after the event loop finishes. The event is therefore no longer valid. By adding an explicit call to `event.persist()`, we can ensure that it's safe to pass the event out.

For more details on synthetic events and the event loop, I found this helpful: https://github.com/bensu/basic-om-tut/blob/master/Troubleshooting.md

> **React's SyntheticEvents**
> React's SyntheticEvent documentation describes SyntheticEvents as "a cross-browser wrapper around the browser's native event". The implementation of SyntheticEvent uses the object pool pattern to reduce the frequency of garbage collection. When an event is fired in React, an object from the event pool is used to represent the event. After each event loop, the objects backing these events are cleared of their information and released back to the React's object pool to be used again. A SyntheticEvent can be made to persist across event loops by calling persist on the SyntheticEvent object(e.g. event.persist()).

> SyntheticEvents that are logged to the console or put into core.async channels without having persist() called on them will have no information associated with them when accessed. Event objects should have persist() called on them within the callback handler or event data should be accessed within the callback handler to avoid this.