### PR TITLE
Tests implement context parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,16 +36,18 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.3.13",
     "babel-runtime": "^6.6.1",
-    "jest-cli": "^11.0.2",
+    "jest-cli": "^16.0.1",
     "react-addons-test-utils": "^15.0.1",
     "webpack": "^1.12.14",
     "webpack-babel-jest": "^1.0.4"
   },
   "jest": {
+    "automock": true,
     "moduleFileExtensions": [
       "js",
       "jsx"
     ],
-    "testRegex": "__tests__/.*test.js$"
+    "testRegex": "__tests__/.*test.js$",
+    "unmockedModulePathPatterns": ["react"]
   }
 }

--- a/src/helpers/__tests__/get-view-data-test.js
+++ b/src/helpers/__tests__/get-view-data-test.js
@@ -13,11 +13,23 @@ describe('getViewData', () => {
             errors: true,
             errorClassName: true,
             containerClassName: true,
-            mock_key: 'mock_value'
+            name: 'mock_name',
+            mock_key: 'mock_value',
         };
 
-        let data = getViewData(props);
+        let context = {
+            states: {
+                'mock_key': {
+                    isUsed: false,
+                    isChanged: false
+                },
+                mock_name: {},
+            },
+            errors: {},
+        };
 
-        expect(Object.keys(data.props).length === 1 && data.props.hasOwnProperty('mock_key')).toBe(true);
+        let data = getViewData(props, context);
+
+        expect(data.props.hasOwnProperty('mock_key')).toBe(true);
     });
 });

--- a/src/helpers/__tests__/pull-error-test.js
+++ b/src/helpers/__tests__/pull-error-test.js
@@ -5,6 +5,10 @@ import pullError from './../pull-error.js';
 describe('pullError', () => {
     it('should return force error if marked with :force', () => {
         let data = {
+          name: 'mock_name',
+        };
+
+        let context = {
             name: 'mock_name',
             states: {
                 'mock_name': {
@@ -17,12 +21,15 @@ describe('pullError', () => {
             }
         };
 
-        expect(pullError(data)).toBe('mock_error:force');
+        expect(pullError(data, context)).toBe('mock_error:force');
     });
 
     it('should return true on invalid state and used/changed flags are true', () => {
         let data = {
             name: 'mock_name',
+        };
+
+        let context = {
             states: {
                 'mock_name': {
                     isUsed: true,
@@ -34,11 +41,15 @@ describe('pullError', () => {
             }
         };
 
-        expect(pullError(data)).toBe('mock_error');
+        expect(pullError(data, context)).toBe('mock_error');
     });
 
     it('should return false on invalid state and one of used/changed flags is false', () => {
         let data = {
+            name: 'mock_name',
+        };
+
+        let context = {
             name: 'mock_name',
             states: {
                 'mock_name': {
@@ -51,6 +62,6 @@ describe('pullError', () => {
             }
         };
 
-        expect(pullError(data)).toBe(false);
+        expect(pullError(data, context)).toBe(false);
     });
 });

--- a/src/helpers/__tests__/pull-error-test.js
+++ b/src/helpers/__tests__/pull-error-test.js
@@ -9,7 +9,6 @@ describe('pullError', () => {
         };
 
         let context = {
-            name: 'mock_name',
             states: {
                 'mock_name': {
                     isUsed: false,
@@ -50,7 +49,6 @@ describe('pullError', () => {
         };
 
         let context = {
-            name: 'mock_name',
             states: {
                 'mock_name': {
                     isUsed: true,

--- a/src/helpers/__tests__/pull-value-test.js
+++ b/src/helpers/__tests__/pull-value-test.js
@@ -7,15 +7,21 @@ describe('pullValue', () => {
         let data = {
             name: 'mock_name',
             value: 'mock_value',
-            states: {}
         };
 
-        expect(pullValue(data)).toBe('mock_value');
+        let context = {
+            states: {},
+        };
+
+        expect(pullValue(data, context)).toBe('mock_value');
     });
 
     it('should return state.value if exists', () => {
         let data = {
             name: 'mock_name',
+        };
+
+        let context = {
             value: 'mock_value',
             states: {
                 'mock_name': {
@@ -24,6 +30,6 @@ describe('pullValue', () => {
             }
         };
 
-        expect(pullValue(data)).toBe('mock_state_value');
+        expect(pullValue(data, context)).toBe('mock_state_value');
     });
 });


### PR DESCRIPTION
Hey Oleksii, I ran into a few issues running `jest-cli 11.0.2` so bumped the version up to latest and made some changes to the `package.json` to work with the new version. Let me know if you'd prefer this in a seperate PR.

Otherwise, I implemented the recent changes made to the helper functions and pass context as the second parameter to the tested functions. They seem to be passing now.

One notable change I made is removing the key length check in `get-view-data-test.js`.

The motiviation for doing this was to look into issue #50, though noticed there were no tests for the components. I've started going down that path, but actually have a few questions and would love your feedback on what libraries you'd prefer we use for testing here? I think at minimum we'd need `react-dom`, but something like `enzyme` might also make life easier for us. Feedback?

Thanks for reviewing!