### PR TITLE
Add existingState property to Form component

### DIFF
--- a/src/components/form/index.js
+++ b/src/components/form/index.js
@@ -9,10 +9,11 @@ class Form extends Component {
     validateAll: PropTypes.func.isRequired,
     showError: PropTypes.func.isRequired,
     hideError: PropTypes.func.isRequired,
+    existingState: PropTypes.object,
   };
 
   render() {
-    const { getValues, validate, validateAll, showError, hideError, ...props } = this.props;
+    const { getValues, validate, validateAll, showError, hideError, existingState, ...props } = this.props;
 
     return (
       <form {...props} />

--- a/src/hocs/form/index.js
+++ b/src/hocs/form/index.js
@@ -8,7 +8,9 @@ export default function form (WrappedComponent) {
   return class extends PureComponent {
     static displayName = `Form(${WrappedComponent.name})`;
 
-    static propTypes = {};
+    static propTypes = {
+      existingState: PropTypes.object,
+    };
 
     static childContextTypes = {
       _register: PropTypes.func.isRequired,
@@ -42,6 +44,11 @@ export default function form (WrappedComponent) {
     }
 
     _register = (component, id) => {
+      const { existingState } = this.props;
+      const value =
+        component.props.value ||
+        (existingState && existingState[component.props.name]) ||
+        '';
       this.setState(state => ({
         byName: {
           ...state.byName,
@@ -52,7 +59,7 @@ export default function form (WrappedComponent) {
           [id]: {
             ...component.props,
             isCheckable: _isCheckable(component),
-            value: component.props.value || '',
+            value,
             ...(_isCheckable(component) ? { checked: !!component.props.checked } : {})
           }
         }


### PR DESCRIPTION
Adds `existingState` property to the `<Form />` component.

Pre-populates a form with existing data in a manner consistent with `form.getValues()`.

```js
import Form from 'react-validation/build/form';

const state = {
  title: "Existing Title",
  description: "An existing description.",
};

<Form existingState={state} />
  <TextInput name="title" validations={[required]} />
  <TextArea name="description" validations{[required]} />
</Form>
```

This is useful for CRUD applications where the same form will be used for both creating and editing.