### PR TITLE
Add props to show wrapper class name and label component

### DIFF
--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -4,11 +4,11 @@ import control from '../../hocs/control';
 
 const Input = ({ error, isChanged, isUsed, wrapperClassName, labelComponent, ...props }) => (
   <div className={wrapperClassName}>
+    {labelComponent}
     <input {...props} {...( isChanged && isUsed && error ? {
       className: `is-invalid-input ${props.className}`
     } : { className: props.className } )} />
     {isChanged && isUsed && error}
-    {labelComponent}
   </div>
 );
 

--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -2,16 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import control from '../../hocs/control';
 
-const Input = ({ error, isChanged, isUsed, ...props }) => (
-  <div>
+const Input = ({ error, isChanged, isUsed, wrapperClassName, labelComponent, ...props }) => (
+  <div className={wrapperClassName}>
     <input {...props} {...( isChanged && isUsed && error ? {
       className: `is-invalid-input ${props.className}`
     } : { className: props.className } )} />
     {isChanged && isUsed && error}
+    {labelComponent}
   </div>
 );
 
 Input.propTypes = {
+  labelComponent: PropTypes.node,
+  wrapperClassName: PropTypes.string,
   error: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
 };
 

--- a/src/components/select/index.js
+++ b/src/components/select/index.js
@@ -2,14 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import control from '../../hocs/control';
 
-const Select = ({ error, isChanged, isUsed, ...props }) => (
-  <div>
+const Select = ({ error, isChanged, isUsed, wrapperClassName, labelComponent, ...props }) => (
+  <div className={wrapperClassName}>
     <select {...props} />
     {isChanged && isUsed && error}
+    {labelComponent}
   </div>
 );
 
 Select.propTypes = {
+  labelComponent: PropTypes.node,
+  wrapperClassName: PropTypes.string,
   error: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
 };
 

--- a/src/components/select/index.js
+++ b/src/components/select/index.js
@@ -4,9 +4,9 @@ import control from '../../hocs/control';
 
 const Select = ({ error, isChanged, isUsed, wrapperClassName, labelComponent, ...props }) => (
   <div className={wrapperClassName}>
+    {labelComponent}
     <select {...props} />
     {isChanged && isUsed && error}
-    {labelComponent}
   </div>
 );
 

--- a/src/components/textarea/index.js
+++ b/src/components/textarea/index.js
@@ -4,9 +4,9 @@ import control from '../../hocs/control';
 
 const Textarea = ({ error, isChanged, isUsed, wrapperClassName, labelComponent, ...props }) => (
   <div className={wrapperClassName}>
+    {labelComponent}
     <textarea {...props} />
     {isChanged && isUsed && error}
-    {labelComponent}
   </div>
 );
 

--- a/src/components/textarea/index.js
+++ b/src/components/textarea/index.js
@@ -2,14 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import control from '../../hocs/control';
 
-const Textarea = ({ error, isChanged, isUsed, ...props }) => (
-  <div>
+const Textarea = ({ error, isChanged, isUsed, wrapperClassName, labelComponent, ...props }) => (
+  <div className={wrapperClassName}>
     <textarea {...props} />
     {isChanged && isUsed && error}
+    {labelComponent}
   </div>
 );
 
 Textarea.propTypes = {
+  labelComponent: PropTypes.node,
+  wrapperClassName: PropTypes.string,
   error: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
 };
 


### PR DESCRIPTION
Added the following props:

### wrapperClassName
Type: String

Eg:
```js
<Input wrapperClassName="input-wrapper" />
```

### labelComponent
Type: Node

Eg:
```js
<Input labelComponent={<label htmlFor="name">Name</label>} />
```